### PR TITLE
Update 2024-01-02 1619H

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -2,6 +2,7 @@
 
 ## Table of Contents
 + [2023-12-31](#2023-12-31)
++ [2024-01-02](#2024-01-02)
 
 ## Logs
 ### 2023-12-31
@@ -17,4 +18,36 @@
     - Added new document 'docker-compose.yaml' template
     - Added new document 'README.md'
     - Added new shellscript 'make.sh' for automatically running actions
+
+### 2024-01-02
+#### 1619H
+- New
+    - Added new directory 'scripts' to hold all utilities and add-on helper scripts 
+        - Added new bash shellscript 'docker-exec-menu.sh' : A Docker container execution script TUI that will accept the container's name and create a menu in which, the user will just enter all the commands they want to execute (WIP)
+
+- Updates
+    - Updated document 'README.md' with new information on using the Dockerfiles in an existing Dockerfile stack as part of a multi-build staged image build
+    - Updated configuration file 'docker-compose.yaml' with 
+        - Multi-stage Build/Import example
+    - Updated Dockerfile 'x11vnc.Dockerfile' and tested with new features
+        - Usage as a multi-stage image build base image
+        - Fixed issues
+            - passing arguments in the 'docker build' command call (i.e. passing argument into docker build using '--build-args')
+            - Appending commands in 'docker run [image] <commands>' or the 'command:' key-value in docker-compose does not append to the ENTRY POINT; 'docker run'/'docker-compose up' Does nothing on runtime
+        - Temporarily removed some unnecessary lines
+        - Set default SHELL as '/bin/bash'
+        - Added new arguments
+            - VNC_SERVER_SPECS : Explicitly setting your own VNC server specifications during build-time; TODO: Place this as a start-up/run time variable instead so that you can run this as an Environment Variable
+        - Added VNC_SERVER_SPECS into VNC_SERVER_OPTS as a parameter
+        - Added 'exec $0 $@' to ENTRYPOINT to allow commands to be executed after the entrypoint is executed before container has started
+    - Updated bash shellscript 'make.sh' 
+        - Added shebang '/bin/bash' to header
+        - Performed some clean-up refactoring
+            - Reorganized variables
+        - Added comments to some variables
+        - Converted variable 'build_opts' for docker Build Options from string into arrays
+        - Issues
+            - build()
+                - Temporarily converted 'cmd_build' into the command string itself because bash (or docker build specifically) clearly hates running commands with arguments that has spaces in them
+                    - TODO: Will fix later; for now, just use it in-line
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,18 +1,30 @@
 # Docker compose recipe for running both x11vnc and tigervncserver
 version: "3.7"
 services:
+    websocket-x-stage-1:
+      image: thanatisia/websocket-x:latest
+      build:
+        context: .
+        args:
+          - VNC_SERVER_PASS=[your-vnc-server-password-here]
+          - "FRAMEBUFFER_SCREEN_SPECS=-screen 0 1920x1080x16"
+        dockerfile: docker/Dockerfiles/debian/[vnc-server].Dockerfile
+
+    # UNCOMMENT THIS IF YOU ARE USING THIS AS A MULTI-STAGE BUILD (i.e. importing the main Dockerfile as a reference)
+    # websocket-x-stage-2:
+    #  image: thanatisia/websocket-x:latest
+    #  build:
+    #    context: .
+    #    dockerfile: docker/Dockerfiles/debian/stage-2.Dockerfile
+
     browser-x:
-        image: thanatisia/websocket-x:latest
-        container_name:  browser-x
-        build:
-          context: .
-          args:
-            - VNC_SERVER_PASS=[your-vnc-server-password-here]
-          dockerfile: docker/Dockerfiles/debian/[target-vnc-server].Dockerfile
-        restart: unless-stopped
-        ports:
-          ## Port Forward/Translate/Map host system port to container port
-          ## [ip-address]:[host-system-port]:[container-port]
-          - 5900:5900 # VNC Server listening port
-          - 6080:6080 # Websocket server listening port
+      image: thanatisia/websocket-x:latest
+      container_name:  browser-x
+      # restart: unless-stopped
+      tty: true
+      ports:
+        ## Port Forward/Translate/Map host system port to container port
+        ## [ip-address]:[host-system-port]:[container-port]
+        - 5900:5900 # VNC Server listening port
+        - 6080:6080 # Websocket server listening port
 

--- a/docker/Dockerfiles/debian/x11vnc.Dockerfile
+++ b/docker/Dockerfiles/debian/x11vnc.Dockerfile
@@ -10,10 +10,14 @@ RUN apt update -y && apt upgrade -y && \
 ## Target 'server'
 FROM setup AS server
 
+## Set SHELL
+SHELL ["/bin/bash", "-c"]
+
 ## Set Build-time Arguments
 ## - To invoke and specify: `docker build --build-arg [ARGUMENT_VARIABLE]=[ARGUMENT_VALUE]`
 ARG VNC_SERVER_PASS=
-ARG FRAMEBUFFER_SCREEN_SPECS="-screen 0 1024x768x16"
+ARG VNC_SERVER_SPECS=
+ARG FRAMEBUFFER_SCREEN_SPECS="-screen 0 1920x1080x16"
 
 ## Set Run-time Environment Variables
 ## - To invoke and specify: `[ENVIRONMENT_VARIABLE]=[VALUE] docker build`
@@ -27,7 +31,7 @@ ENV FRAMEBUFFER_OPTS="${DISPLAY} ${FRAMEBUFFER_SCREEN_SPECS}"
 ### VNC server
 ENV VNC_SERVER_HOST=127.0.0.1
 ENV VNC_SERVER_PORT=5900
-ENV VNC_SERVER_OPTS="-display ${DISPLAY} -rfbport ${VNC_SERVER_PORT} -usepw -passwd ${VNC_SERVER_PASS} -xkb -forever -shared"
+ENV VNC_SERVER_OPTS="-display ${DISPLAY} -rfbport ${VNC_SERVER_PORT} ${VNC_SERVER_SPECS} -usepw -passwd ${VNC_SERVER_PASS} -xkb -forever -bg -shared"
 
 ### Websocket server
 ENV WEBSOCKET_CLIENT_PATH=/usr/share/novnc
@@ -40,6 +44,14 @@ RUN touch -- $HOME/.Xauthority && \
     chmod u+x $HOME/.Xauthority && \
     xauth add "${DISPLAY}" MIT-MAGIC-COOKIE-1 "$(od -An -N16 -tx /dev/urandom | tr -d ' ')" 
 
+## Startup Xorg Virtual Framebuffer to allow drawing/rendering of Graphical Applications within the background as a process
+#RUN Xvfb ${FRAMEBUFFER_OPTS} & { \
+#    ## Start Websocket and VNC server \
+#    websockify -D --web=${WEBSOCKET_CLIENT_PATH} ${WEBSOCKET_SERVER_PORT} ${VNC_SERVER_HOST}:${VNC_SERVER_PORT}; \
+#    ## Startup VNC server within the Virtual Framebuffer environment \ 
+#    x11vnc ${VNC_SERVER_OPTS}; \
+#}
+
 ## Networking
 ### Specify ports to expose
 #### 6080 = WebSocket server port
@@ -49,9 +61,25 @@ RUN touch -- $HOME/.Xauthority && \
 
 ## Set Entry point command
 ## Startup Xorg Virtual Framebuffer to allow drawing/rendering of Graphical Applications within the background as a process
-ENTRYPOINT Xvfb ${FRAMEBUFFER_OPTS} & { \
+# ENTRYPOINT ["bash"]
+
+#ENTRYPOINT Xvfb ${FRAMEBUFFER_OPTS} & \
+#    ## Startup VNC server within the Virtual Framebuffer environment and websocket server to point to Web/Browser-based VNC client \
+#    websockify -D --web=${WEBSOCKET_CLIENT_PATH} ${WEBSOCKET_SERVER_PORT} ${VNC_SERVER_HOST}:${VNC_SERVER_PORT}; \
+#    x11vnc ${VNC_SERVER_OPTS} && \
+#    exec $@
+
+ENTRYPOINT Xvfb ${FRAMEBUFFER_OPTS} & \
     ## Startup VNC server within the Virtual Framebuffer environment and websocket server to point to Web/Browser-based VNC client \
-    websockify -D --web=${WEBSOCKET_CLIENT_PATH} ${WEBSOCKET_SERVER_PORT} ${VNC_SERVER_HOST}:${VNC_SERVER_PORT}; \
     x11vnc ${VNC_SERVER_OPTS}; \
-}
+    websockify -D --web=${WEBSOCKET_CLIENT_PATH} ${WEBSOCKET_SERVER_PORT} ${VNC_SERVER_HOST}:${VNC_SERVER_PORT} && \ 
+    ## $0 will take the executable's name (1st argument) \
+    ## $@ will take all subsequent arguments (parameters) \
+    ## Summary: \
+    ## - argument [0] as the executable, and \
+    ## - arguments [1:] as the parameters \
+    exec "$0" "$@"
+
+## Set default command to execute after ENTRYPOINT if commands are not specified
+## Startup websocket server to point to Web/Browser-based VNC client
 

--- a/scripts/docker-exec-menu.sh
+++ b/scripts/docker-exec-menu.sh
@@ -1,0 +1,46 @@
+#!/bin/env bash
+: "
+Docker container execution script
+
+- Operational Flow
+    - For/While loop until break condition is met
+        - Break Conditions
+            - If keyword 'q' or 'quit' is entered
+        - Get user input
+            - Sanitize
+        - Enter the container
+            - Execute command as a background process '&'
+"
+# Initialize Variables
+container_name="${1:-""}"
+shell="${SHELL:-/bin/bash}"
+input_str=""
+
+# Check if container is provided
+if [[ "$container_name" != "" ]]; then
+    # Check if container exists
+    # Begin execution menu
+    while true; do
+        # Get user input
+        read -p "> " input_str
+        
+        # Break condition
+        if [[ "$input_str" == "q" ]] || [[ "$input_str" == "quit" ]]; then
+            exit
+        else
+            # Execute command in container
+            docker exec -t $container_name $shell -c "$input_str" &
+        fi
+
+        # Sleep for half a second to flush and finish the previous standard output before proceeding
+        sleep 0.5
+
+        # Reset user input
+        input_str=""
+    done
+    # echo -e "Container $container_name does not exists."
+else
+    echo -e "Container not provided."
+fi
+
+


### PR DESCRIPTION
- New
    - Added new directory 'scripts' to hold all utilities and add-on helper scripts 
        - Added new bash shellscript 'docker-exec-menu.sh' : A Docker container execution script TUI that will accept the container's name and create a menu in which, the user will just enter all the commands they want to execute (WIP)

- Updates
    - Updated document 'README.md' with new information on using the Dockerfiles in an existing Dockerfile stack as part of a multi-build staged image build
    - Updated configuration file 'docker-compose.yaml' with 
        - Multi-stage Build/Import example
    - Updated Dockerfile 'x11vnc.Dockerfile' and tested with new features
        - Usage as a multi-stage image build base image
        - Fixed issues
            - passing arguments in the 'docker build' command call (i.e. passing argument into docker build using '--build-args')
            - Appending commands in 'docker run [image] <commands>' or the 'command:' key-value in docker-compose does not append to the ENTRY POINT; 'docker run'/'docker-compose up' Does nothing on runtime
        - Temporarily removed some unnecessary lines
        - Set default SHELL as '/bin/bash'
        - Added new arguments
            - VNC_SERVER_SPECS : Explicitly setting your own VNC server specifications during build-time; TODO: Place this as a start-up/run time variable instead so that you can run this as an Environment Variable
        - Added VNC_SERVER_SPECS into VNC_SERVER_OPTS as a parameter
        - Added 'exec $0 $@' to ENTRYPOINT to allow commands to be executed after the entrypoint is executed before container has started
    - Updated bash shellscript 'make.sh' 
        - Added shebang '/bin/bash' to header
        - Performed some clean-up refactoring
            - Reorganized variables
        - Added comments to some variables
        - Converted variable 'build_opts' for docker Build Options from string into arrays
        - Issues
            - build()
                - Temporarily converted 'cmd_build' into the command string itself because bash (or docker build specifically) clearly hates running commands with arguments that has spaces in them
                    - TODO: Will fix later; for now, just use it in-line